### PR TITLE
Update debian control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -87,7 +87,7 @@ Depends:
  ${misc:Depends}
  ${shlibs:Depends}
 Provides:
- sssd,
+ sssd (= 2.9.4),
  sssd-common,
  sssd-ad,
  sssd-ad-common,
@@ -110,6 +110,7 @@ Provides:
  libsss-idmap0,
  libsss-nss-idmap0,
  libsss-sudo,
+ python3-sss,
  python3-libipa-hbac,
  python3-libsss-nss-idmap,
 Description: System Security Services Daemon


### PR DESCRIPTION
Apply some changes to debian control to satisfy runtime requirements for freeipa-client.

* specify sssd version
* note that provides python3-sss